### PR TITLE
Rationalize Versions

### DIFF
--- a/charts/cluster-api-cluster-openstack/Chart.yaml
+++ b/charts/cluster-api-cluster-openstack/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-api-cluster-openstack
 description: A Helm chart to deploy a Kubernetes Cluster
 type: application
-version: v0.4.4
+version: v0.5.0
 icon: https://raw.githubusercontent.com/unikorn-cloud/helm-cluster-api/main/icons/default.png

--- a/charts/cluster-api-cluster-openstack/README.md
+++ b/charts/cluster-api-cluster-openstack/README.md
@@ -36,7 +36,7 @@ spec:
   source:
     repoURL: https://unikorn-cloud.github.io/helm-cluster-api
     chart: cluster-api-cluster-openstack
-    targetRevision: v0.4.4
+    targetRevision: v0.5.0
     helm:
       releaseName: foo
       # Remove the default work queue.

--- a/charts/cluster-api-cluster-openstack/templates/_helpers.tpl
+++ b/charts/cluster-api-cluster-openstack/templates/_helpers.tpl
@@ -16,14 +16,6 @@ dev/staging/production CAPI instances.
 {{- printf "%s-cloud-config" .Release.Name }}
 {{- end }}
 
-{{- define "kubeadmcontrolplane.name" }}
-{{- if .Values.legacyResourceNames }}
-  {{- printf "%s-control-plane" .Release.Name }}
-{{- else }}
-  {{- .Release.Name }}
-{{- end }}
-{{- end }}
-
 {{/*
 The machine templates are a bit special in that their names will directly
 influence the hostnames of the nodes.

--- a/charts/cluster-api-cluster-openstack/templates/cluster.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/cluster.yaml
@@ -25,7 +25,7 @@ spec:
   controlPlaneRef:
     kind: KubeadmControlPlane
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-    name: {{ include "kubeadmcontrolplane.name" . }}
+    name: {{ .Release.Name }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackCluster

--- a/charts/cluster-api-cluster-openstack/templates/control-plane.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/control-plane.yaml
@@ -2,14 +2,14 @@
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 metadata:
-  name: {{ include "kubeadmcontrolplane.name" . }}
+  name: {{ .Release.Name }}
   labels:
     {{- include "openstackcluster.labels" . | nindent 4 }}
   annotations:
     # Let CAPO do this in its chosen order.
     argocd.argoproj.io/sync-options: Delete=false
 spec:
-  version: "{{ .Values.controlPlane.version }}"
+  version: "{{ .Values.version }}"
   replicas: {{ .Values.controlPlane.replicas }}
   machineTemplate:
     infrastructureRef:

--- a/charts/cluster-api-cluster-openstack/templates/workload.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/workload.yaml
@@ -12,11 +12,6 @@ The resource names are common all over the place, so define in a canonical locat
 */}}
 {{- $pool_name := printf "%s-pool-%s" $.Release.Name ( $name | sha256sum | trunc 8 ) }}
 {{- $pool_name_discriminated := printf "%s-pool-%s-%s"  $.Release.Name ( $name | sha256sum | trunc 8 ) ( include "openstack.discriminator.workload" $context ) }}
-
-{{- if $values.legacyResourceNames }}
-  {{- $pool_name = printf "%v-pool-%v" $.Release.Name $name }}
-  {{- $pool_name_discriminated = printf "%v-pool-%v-%v" $.Release.Name $name (include "openstack.discriminator.workload" $context) }}
-{{- end }}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -39,7 +34,7 @@ spec:
   template:
     spec:
       clusterName: {{ include "cluster.name" $ }}
-      version: "{{ $pool.version }}"
+      version: "{{ $.Values.version }}"
       failureDomain: {{ include "openstack.failureDomain.compute.workload" $context }}
       bootstrap:
         configRef:

--- a/charts/cluster-api-cluster-openstack/values.schema.json
+++ b/charts/cluster-api-cluster-openstack/values.schema.json
@@ -125,14 +125,10 @@
 		"workloadMachineSet": {
 			"type": "object",
 			"required": [
-				"version",
 				"replicas",
 				"machine"
 			],
 			"properties": {
-				"version": {
-                                        "$ref": "#/$defs/semanticVersion"
-                                },
 				"replicas": {
 					"$ref": "#/$defs/nonNegativeNumber"
 				},
@@ -218,17 +214,18 @@
 	},
 	"type": "object",
 	"required": [
+		"version",
 		"labelDomain",
 		"openstack",
 		"controlPlane",
 		"network"
 	],
 	"properties": {
+		"version": {
+			"$ref": "#/$defs/semanticVersion"
+		},
 		"labelDomain": {
 			"type": "string"
-		},
-		"legacyResourceNames": {
-			"type": "boolean"
 		},
 		"openstack": {
 			"type:": "object",
@@ -299,14 +296,10 @@
                 "controlPlane": {
 			"type": "object",
 			"required": [
-				"version",
 				"replicas",
 				"machine"
 			],
 			"properties": {
-				"version": {
-                                        "$ref": "#/$defs/semanticVersion"
-                                },
 				"replicas": {
 					"$ref": "#/$defs/nonNegativeNumber"
 				},

--- a/charts/cluster-api-cluster-openstack/values.yaml
+++ b/charts/cluster-api-cluster-openstack/values.yaml
@@ -1,13 +1,10 @@
 # Label domain for implicit labels defined in this chart.
 labelDomain: unikorn-cloud.org
 
-# Legacy resource names are very easy to go over the 63 character resource name
-# limit as you can imagine a 53 character release concatenated with an arbitrary
-# sized pool name, and a random instance ID.  With this set to false, we'll put
-# tainted inputs through SHA2 and extract an 8 character substring (that's still
-# 4 billion possible outcomes).  Try to kee the release name in the ~20 character
-# range to avoid overflows (if this means hashing, do it).
-legacyResourceNames: false
+# Version of Kubernetes, should match that pre-installed on the base images
+# otherwise you'll have to pay a start-up penalty as kubeadm downloads the
+# images.
+version: v1.30.2
 
 # OpenStack specific configuration.
 # Contains credentials for the cloud, networking options and other
@@ -72,9 +69,6 @@ openstack:
 # Control plane topology.
 # Modifications to this object will trigger a control plane upgrade.
 controlPlane:
-  # Version of Kubernetes, should match that installed on the base images.
-  version: v1.30.2
-
   # Number of control plane machines.
   replicas: 3
 
@@ -108,10 +102,6 @@ controlPlane:
 # workloadPools:
 #  # Pool name
 #  default:
-#    # Version of Kubernetes, should match that installed on the base images
-#    # in order to improve provisioning and scaling time.
-#    version: v1.30.2
-#
 #    # Number of workload machines.
 #    replicas: 3
 #


### PR DESCRIPTION
We had to duplicate the Kubernetes version in multiple places, which makes configuration harder, and is a classic case of over-engineering when any iupgrade logic should already be part of CAPI.  I've bumped this to a new major alpha version too as legacy naming is now dead, and we shouldn't be supporting something that is inherently broken because it will just waste time.