### PR TITLE
Add Provider Network Support

### DIFF
--- a/charts/cluster-api-cluster-openstack/Chart.yaml
+++ b/charts/cluster-api-cluster-openstack/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-api-cluster-openstack
 description: A Helm chart to deploy a Kubernetes Cluster
 type: application
-version: v0.5.1
+version: v0.5.2
 icon: https://raw.githubusercontent.com/unikorn-cloud/helm-cluster-api/main/icons/default.png

--- a/charts/cluster-api-cluster-openstack/README.md
+++ b/charts/cluster-api-cluster-openstack/README.md
@@ -36,7 +36,7 @@ spec:
   source:
     repoURL: https://unikorn-cloud.github.io/helm-cluster-api
     chart: cluster-api-cluster-openstack
-    targetRevision: v0.5.1
+    targetRevision: v0.5.2
     helm:
       releaseName: foo
       # Remove the default work queue.

--- a/charts/cluster-api-cluster-openstack/templates/cluster.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/cluster.yaml
@@ -52,6 +52,10 @@ spec:
     {{- end }}
   managedSecurityGroups:
     allowAllInClusterTraffic: true
+  {{- if .Values.network.networkID }}
+  network:
+    id: {{ .Values.network.networkID }}
+  {{- end }}
   managedSubnets:
   - cidr: {{ .Values.network.nodeCIDR }}
     dnsNameservers: {{ toJson .Values.network.dnsNameservers }}

--- a/charts/cluster-api-cluster-openstack/values.schema.json
+++ b/charts/cluster-api-cluster-openstack/values.schema.json
@@ -340,7 +340,10 @@
                                 },
                                 "dnsNameservers": {
 					"$ref": "#/$defs/nonEmptyIPV4List"
-                                }
+                                },
+				"networkID": {
+					"type": "string"
+				}
 			}
 		}
 	}

--- a/charts/cluster-api-cluster-openstack/values.yaml
+++ b/charts/cluster-api-cluster-openstack/values.yaml
@@ -188,3 +188,8 @@ network:
   # DNS nameservers to use.
   dnsNameservers:
   - 8.8.8.8
+
+  # If specified defines an existing nwtork to use, if not defined a network
+  # will be created by CAPO.  This allows you to use non-standard network
+  # types e.g. a VLAN to be used for baremetal nodes.
+  # networkID: 8f526b54-fab3-435d-b4b3-f65fd8474b8a


### PR DESCRIPTION
Sadly, CAPO isn't allowed to create "non-standar" network types, so we need to provision one externally and pass it in.  Hopefully, according to the code, it'll add the L3 subnet and router for us.