### PR TITLE
Increase Machine Check Timeouts

### DIFF
--- a/charts/cluster-api-cluster-openstack/Chart.yaml
+++ b/charts/cluster-api-cluster-openstack/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-api-cluster-openstack
 description: A Helm chart to deploy a Kubernetes Cluster
 type: application
-version: v0.5.3
+version: v0.5.4
 icon: https://raw.githubusercontent.com/unikorn-cloud/helm-cluster-api/main/icons/default.png

--- a/charts/cluster-api-cluster-openstack/README.md
+++ b/charts/cluster-api-cluster-openstack/README.md
@@ -36,7 +36,7 @@ spec:
   source:
     repoURL: https://unikorn-cloud.github.io/helm-cluster-api
     chart: cluster-api-cluster-openstack
-    targetRevision: v0.5.3
+    targetRevision: v0.5.4
     helm:
       releaseName: foo
       # Remove the default work queue.

--- a/charts/cluster-api-cluster-openstack/templates/machinehealthcheck.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/machinehealthcheck.yaml
@@ -10,7 +10,8 @@ metadata:
 spec:
   clusterName: {{ include "cluster.name" . }}
   maxUnhealthy: 50%
-  nodeStartupTimeout: 10m0s
+  # Note this is really relaxed because of ironic taking forever.
+  nodeStartupTimeout: 2h0m0s
   selector:
     matchLabels:
       cluster.x-k8s.io/cluster-name: {{ include "cluster.name" . }}


### PR DESCRIPTION
Ironic can take a long time, like between 15-30 minutes to spin up a machine.  The timeout value is deliberately very lax e.g. 2h initially to allow time to SSH in and debug errors.  Eventually we should be able to specify timeouts based on machine type, e.g. VMs will be pretty much instant, whereas baremetal will take longer.