### PR TITLE
Add Firewall Rules to Cluster Nodes

### DIFF
--- a/charts/cluster-api-cluster-openstack/Chart.yaml
+++ b/charts/cluster-api-cluster-openstack/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-api-cluster-openstack
 description: A Helm chart to deploy a Kubernetes Cluster
 type: application
-version: v0.5.4
+version: v0.5.5
 icon: https://raw.githubusercontent.com/unikorn-cloud/helm-cluster-api/main/icons/default.png

--- a/charts/cluster-api-cluster-openstack/README.md
+++ b/charts/cluster-api-cluster-openstack/README.md
@@ -36,7 +36,7 @@ spec:
   source:
     repoURL: https://unikorn-cloud.github.io/helm-cluster-api
     chart: cluster-api-cluster-openstack
-    targetRevision: v0.5.4
+    targetRevision: v0.5.5
     helm:
       releaseName: foo
       # Remove the default work queue.

--- a/charts/cluster-api-cluster-openstack/templates/cluster.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/cluster.yaml
@@ -52,6 +52,10 @@ spec:
     {{- end }}
   managedSecurityGroups:
     allowAllInClusterTraffic: true
+  {{- if .Values.network.securityGroupRules }}
+    allNodesSecurityGroupRules:
+    {{- toYaml .Values.network.securityGroupRules | nindent 4 }}
+  {{- end }}
   {{- if .Values.network.provider }}
   network:
     id: {{ .Values.network.provider.networkID }}

--- a/charts/cluster-api-cluster-openstack/values.schema.json
+++ b/charts/cluster-api-cluster-openstack/values.schema.json
@@ -355,6 +355,47 @@
 							"type": "string"
 						}
 					}
+				},
+				"securityGroupRules": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"required": [
+							"name",
+							"direction"
+						],
+						"properties": {
+							"name": {
+								"type": "string"
+							},
+							"direction": {
+								"type": "string",
+								"enum": [
+									"ingress",
+									"egress"
+								]
+							},
+							"etherType": {
+								"type": "string",
+								"enum": [
+									"IPv4",
+									"IPv6"
+								]
+							},
+							"protocol": {
+								"type": "string",
+								"enum": [
+									"TCP"
+								]
+							},
+							"portRangeMin": {
+								"type": "integer"
+							},
+							"portRangeMax": {
+								"type": "integer"
+							}
+						}
+					}
 				}
 			}
 		}

--- a/charts/cluster-api-cluster-openstack/values.yaml
+++ b/charts/cluster-api-cluster-openstack/values.yaml
@@ -196,3 +196,12 @@ network:
   # provider:
   #   networkID: 8f526b54-fab3-435d-b4b3-f65fd8474b8a
   #   subnetID: e3b15dd0-17e4-47c0-bc6c-1b8ea1f1018f
+
+  # If specified these security group rules are added to all nodes.
+  # securityGroupRules:
+  # - name: ssh-ingress
+  #   direction: ingress
+  #   etherType: IPv4
+  #   protocol: TCP
+  #   portRangeMin: 22
+  #   portRangeMax: 22


### PR DESCRIPTION
At present you cannot add ephemeral rules to security groups for debug as that will ultimately get reverted and drive you insane, so allow the client to set some up e.g. SSH access for debugging.