### PR TITLE
Enable parallel image pulls

### DIFF
--- a/charts/cluster-api-cluster-openstack/Chart.yaml
+++ b/charts/cluster-api-cluster-openstack/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-api-cluster-openstack
 description: A Helm chart to deploy a Kubernetes Cluster
 type: application
-version: v0.5.6
+version: v0.5.7
 icon: https://raw.githubusercontent.com/unikorn-cloud/helm-cluster-api/main/icons/default.png

--- a/charts/cluster-api-cluster-openstack/README.md
+++ b/charts/cluster-api-cluster-openstack/README.md
@@ -36,7 +36,7 @@ spec:
   source:
     repoURL: https://unikorn-cloud.github.io/helm-cluster-api
     chart: cluster-api-cluster-openstack
-    targetRevision: v0.5.6
+    targetRevision: v0.5.7
     helm:
       releaseName: foo
       # Remove the default work queue.

--- a/charts/cluster-api-cluster-openstack/templates/control-plane.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/control-plane.yaml
@@ -22,7 +22,6 @@ spec:
         name: {{ "'{{ local_hostname }}'" }}
         kubeletExtraArgs:
           cloud-provider: external
-          serialize-image-pulls: "true"
           node-labels: {{- include "openstack.nodelabels.control-plane" . | nindent 12 }}
         taints:
           {{- include "openstack.taints.control-plane" . | nindent 8 }}
@@ -30,15 +29,18 @@ spec:
       skipPhases:
         {{- toYaml $.Values.controlPlane.kubeadmSkipPhases | nindent 6 }}
       {{- end }}
+      patches:
+        directory: /etc/kubernetes/patches
     joinConfiguration:
       nodeRegistration:
         name: {{ "'{{ local_hostname }}'" }}
         kubeletExtraArgs:
           cloud-provider: external
-          serialize-image-pulls: "true"
           node-labels: {{- include "openstack.nodelabels.control-plane" . | nindent 12 }}
         taints:
           {{- include "openstack.taints.control-plane" . | nindent 8 }}
+      patches:
+        directory: /etc/kubernetes/patches
     clusterConfiguration:
       apiServer:
         extraArgs:
@@ -65,6 +67,16 @@ spec:
         extraArgs:
           authorization-always-allow-paths: "/healthz,/readyz,/livez,/metrics"
           bind-address: "0.0.0.0"
+    files:
+    {{- with $config := .Values.controlPlane.kubelet -}}
+    {{ $_ := set $config "apiVersion" "kubelet.config.k8s.io/v1beta1" -}}
+    {{ $_ := set $config "kind" "KubeletConfiguration" }}
+    - path: /etc/kubernetes/patches/kubeletconfiguration0+strategic.json
+      owner: "root:root"
+      permissions: "0644"
+      content: |
+        {{ $config | toJson }}
+    {{- end }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackMachineTemplate

--- a/charts/cluster-api-cluster-openstack/templates/control-plane.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/control-plane.yaml
@@ -22,6 +22,7 @@ spec:
         name: {{ "'{{ local_hostname }}'" }}
         kubeletExtraArgs:
           cloud-provider: external
+          serialize-image-pulls: "true"
           node-labels: {{- include "openstack.nodelabels.control-plane" . | nindent 12 }}
         taints:
           {{- include "openstack.taints.control-plane" . | nindent 8 }}
@@ -34,6 +35,7 @@ spec:
         name: {{ "'{{ local_hostname }}'" }}
         kubeletExtraArgs:
           cloud-provider: external
+          serialize-image-pulls: "true"
           node-labels: {{- include "openstack.nodelabels.control-plane" . | nindent 12 }}
         taints:
           {{- include "openstack.taints.control-plane" . | nindent 8 }}

--- a/charts/cluster-api-cluster-openstack/templates/workload.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/workload.yaml
@@ -107,6 +107,15 @@ spec:
         path: {{ $file.path }}
         permissions: "0600"
       {{- end }}
+      {{- with $config := $pool.kubelet -}}
+      {{ $_ := set $config "apiVersion" "kubelet.config.k8s.io/v1beta1" -}}
+      {{ $_ := set $config "kind" "KubeletConfiguration" }}
+      - path: /etc/kubernetes/patches/kubeletconfiguration0+strategic.json
+        owner: "root:root"
+        permissions: "0644"
+        content: |
+          {{ $config | toJson }}
+      {{- end }}
       joinConfiguration:
         nodeRegistration:
           name: {{ "'{{ local_hostname }}'" }}
@@ -115,4 +124,8 @@ spec:
             node-labels: {{- include "openstack.nodelabels.workload" $context | nindent 14 }}
           taints:
             {{- include "openstack.taints.workload" $ | nindent 10 }}
+        {{- if $pool.kubelet }}
+        patches:
+          directory: /etc/kubernetes/patches
+        {{- end }}
 {{- end }}

--- a/charts/cluster-api-cluster-openstack/values.yaml
+++ b/charts/cluster-api-cluster-openstack/values.yaml
@@ -138,6 +138,11 @@ controlPlane:
 #    - path: /etc/cat
 #      content: bWVvdw==
 #
+#    # Additional configuration to be passed to the kubelet can be specifed here
+#    kubelet:
+#      # For example:
+#      serializeImagePulls: "false"
+#
 #    # Enable or disable cluster autoscaling.
 #    # This object is considered immutable.
 #    autoscaling:

--- a/charts/cluster-api-cluster-openstack/values.yaml
+++ b/charts/cluster-api-cluster-openstack/values.yaml
@@ -98,6 +98,10 @@ controlPlane:
     # Set the server group of the control plane (e.g. anti-affinity rules).
     # serverGroupID: foo
 
+  # Any additional configuration to be passed to the kubelet can be specifed here
+  kubelet:
+    serializeImagePulls: false
+
 # Workload pools topology.
 # workloadPools:
 #  # Pool name
@@ -141,7 +145,7 @@ controlPlane:
 #    # Additional configuration to be passed to the kubelet can be specifed here
 #    kubelet:
 #      # For example:
-#      serializeImagePulls: "false"
+#      serializeImagePulls: false
 #
 #    # Enable or disable cluster autoscaling.
 #    # This object is considered immutable.


### PR DESCRIPTION
As of 1.27, Kubernetes added support for parallelizing image pulls but this is not enabled by default.  This is especially useful in situations where multiple images need to be downloaded to a host, but one of them is particularly large.