### PR TITLE
Increase Timeouts for BM Reboots

### DIFF
--- a/charts/cluster-api-cluster-openstack/Chart.yaml
+++ b/charts/cluster-api-cluster-openstack/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-api-cluster-openstack
 description: A Helm chart to deploy a Kubernetes Cluster
 type: application
-version: v0.5.7
+version: v0.5.8
 icon: https://raw.githubusercontent.com/unikorn-cloud/helm-cluster-api/main/icons/default.png

--- a/charts/cluster-api-cluster-openstack/README.md
+++ b/charts/cluster-api-cluster-openstack/README.md
@@ -36,7 +36,7 @@ spec:
   source:
     repoURL: https://unikorn-cloud.github.io/helm-cluster-api
     chart: cluster-api-cluster-openstack
-    targetRevision: v0.5.7
+    targetRevision: v0.5.8
     helm:
       releaseName: foo
       # Remove the default work queue.

--- a/charts/cluster-api-cluster-openstack/templates/machinehealthcheck.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/machinehealthcheck.yaml
@@ -17,11 +17,12 @@ spec:
       cluster.x-k8s.io/cluster-name: {{ include "cluster.name" . }}
   unhealthyConditions:
   # If the machine is shutdown for whatever reason, it looks like this
-  # usualy live-migration gone bad.
+  # usualy live-migration gone bad.  45m is a "safe" default for baremetal
+  # nodes that take an absolute age to POST.
   - type: Ready
     status: Unknown
-    timeout: 10m0s
+    timeout: 45m0s
   # Assuming this rolls up any other error...
   - type: Ready
     status: "False"
-    timeout: 10m0s
+    timeout: 45m0s


### PR DESCRIPTION
Due to big servers taking literally forever to POST it's not beyond the realms of possibility for a server during reboot to be kicked out and replaced.