### PR TITLE
Metrics fixes

### DIFF
--- a/charts/cluster-api-control-plane-kubeadm/templates/deployment-0.yaml
+++ b/charts/cluster-api-control-plane-kubeadm/templates/deployment-0.yaml
@@ -55,7 +55,7 @@ spec:
         - containerPort: 9440
           name: healthz
           protocol: TCP
-        - containerPort: 8443
+        - containerPort: 8080
           name: metrics
           protocol: TCP
         readinessProbe:

--- a/charts/cluster-api-provider-openstack/templates/deployment-0.yaml
+++ b/charts/cluster-api-provider-openstack/templates/deployment-0.yaml
@@ -22,7 +22,7 @@ spec:
       - args:
         - --leader-elect
         - --v=2
-        - --diagnostics-address=127.0.0.1:8080
+        - --diagnostics-address=0.0.0.0:8080
         - --insecure-diagnostics=true
         - --logging-format=json
         command:

--- a/charts/openstack-resource-controller/templates/deployment-0.yaml
+++ b/charts/openstack-resource-controller/templates/deployment-0.yaml
@@ -24,6 +24,7 @@ spec:
         - --metrics-bind-address=:8080
         - --leader-elect
         - --health-probe-bind-address=:8081
+        - --metrics-secure=false
         command:
         - /manager
         image: '{{ .Values.image }}'

--- a/patches.yaml
+++ b/patches.yaml
@@ -2,10 +2,19 @@
 - target: 
     kind: Deployment
     name: capo-controller-manager
-    labelSelector: "control-plane=capo-controller-manager"
   patch: |-
     - op: add
       path: '/spec/template/spec/containers/0/ports/-'
+      value:
+        containerPort: 8080
+        name: metrics
+        protocol: TCP
+- target:
+    kind: Deployment
+    name: capi-kubeadm-control-plane-controller-manager
+  patch: |-
+    - op: replace
+      path: '/spec/template/spec/containers/0/ports/2'
       value:
         containerPort: 8080
         name: metrics
@@ -40,7 +49,22 @@
         - containerPort: 8080
           name: metrics
           protocol: TCP
-# Add metrics port to openstack-resource-controller args
+# Replace metrics port in cluster-api provider openstack args
+- target:
+    kind: Deployment
+    name: capo-controller-manager
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/args/2
+      value: --diagnostics-address=0.0.0.0:8080
+# Add metrics port in openstack-resource-controller args
+- target:
+    kind: Deployment
+    name: orc-controller-manager
+  patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --metrics-secure=false
 - target:
     kind: Deployment
     name: orc-controller-manager


### PR DESCRIPTION
fix: added patches for arguments to capo and orc to allow scraping the metrics without auth.

More improvements to metrics, addresses a mistake or two I made in the last PR... 

- Changes the diagnostic address on CAPO to 0.0.0.0 to listen on all interfaces instead of just localhost
- Added --metrics-secure=false to ORC to allow using HTTP and no auth to access metrics
- Adds a metrics port to the capi-kubeadm-controller-manager pod spec

Both have been tested and I've confirmed there are no other controllers using the old metrics config. 