### PR TITLE
Support for specifying containerd registry mirrors

### DIFF
--- a/charts/cluster-api-cluster-openstack/templates/control-plane.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/control-plane.yaml
@@ -86,6 +86,15 @@ spec:
       content: |
         {{ $config | toJson }}
     {{- end }}
+    {{- with .Values.registryMirrors }}
+    {{- range $registry, $mirrors := . }}
+    - path: /etc/containerd/certs.d/{{ $registry }}/hosts.toml
+      owner: root:root
+      permissions: "0644"
+      content: |
+        {{- include "containerd.registry.content" (list $registry $mirrors) | nindent 8 }}
+    {{- end }}
+    {{- end }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackMachineTemplate

--- a/charts/cluster-api-cluster-openstack/templates/workload.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/workload.yaml
@@ -116,6 +116,15 @@ spec:
         content: |
           {{ $config | toJson }}
       {{- end }}
+      {{- with $.Values.registryMirrors }}
+      {{- range $registry, $mirrors := . }}
+      - path: /etc/containerd/certs.d/{{ $registry }}/hosts.toml
+        owner: root:root
+        permissions: "0644"
+        content: |
+          {{- include "containerd.registry.content" (list $registry $mirrors) | nindent 10 }}
+      {{- end }}
+      {{- end }}
       joinConfiguration:
         nodeRegistration:
           name: {{ "'{{ local_hostname }}'" }}

--- a/charts/cluster-api-cluster-openstack/values.yaml
+++ b/charts/cluster-api-cluster-openstack/values.yaml
@@ -71,8 +71,9 @@ openstack:
 # registryMirrors:
 #   docker.io:
 #     # The upstream URL
-#     # If not given, "https://<registry>" is used
-#     # upstream: https://registry-1.docker.io
+#     # If not given, "https://<registry>" is used, except for docker.io which is
+#     # automatically converted to https://registry-1.docker.io
+#     upstream: https://registry-1.docker.io
 #     # The list of mirror endpoints for the repository
 #     endpoints:
 #       - # The URL for the endpoint

--- a/charts/cluster-api-cluster-openstack/values.yaml
+++ b/charts/cluster-api-cluster-openstack/values.yaml
@@ -66,6 +66,33 @@ openstack:
 #  certificateSANs:
 #  - foo.acme.com
 
+# Registry mirrors to configure, e.g. for Docker Hub
+# The keys are registry names and the values are mirror configurations
+# registryMirrors:
+#   docker.io:
+#     # The upstream URL
+#     # If not given, "https://<registry>" is used
+#     # upstream: https://registry-1.docker.io
+#     # The list of mirror endpoints for the repository
+#     endpoints:
+#       - # The URL for the endpoint
+#         url: https://harbor.myorg.com/v2/dockerhub-cache
+#         # The capabilities for the endpoint
+#         # If not given, the default is ["pull", "resolve"]
+#         capabilities: ["pull", "resolve", "push"]
+#         # Indicates whether to skip TLS verification for the endpoint
+#         # Defaults to false if not given
+#         skipVerify: true
+#         # Should be set to true if the endpoint URL includes the full API root
+#         # i.e. containerd does not need to add the /v2 prefix
+#         # Defaults to false if not given
+#         # NOTE: this must be true for Harbor pull-through cache projects
+#         overridePath: true
+#         # Basic authentication for the endpoint, if required
+#         basicAuth:
+#           username: auth-user
+#           password: auth-password
+
 # Control plane topology.
 # Modifications to this object will trigger a control plane upgrade.
 controlPlane:


### PR DESCRIPTION
For a private Harbor pull-through cache project, the required config is:

```yaml
registryMirrors:
  docker.io:
    endpoints:
      - url: https://harbor.myorg.com/v2/dockerhub-cache
        overridePath: true
        basicAuth:
          username: robot-username
          password: robot-token
```