### PR TITLE
Remove --cloud-provider argument from kube-apiserver

### DIFF
--- a/charts/cluster-api-cluster-openstack/templates/control-plane.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/control-plane.yaml
@@ -45,8 +45,6 @@ spec:
       - bash /tmp/kubeadm/patches/kube-apiserver-patch.sh -c {{ .Values.controlPlane.apiServer.cpuLimitPercent }} -m {{ .Values.controlPlane.apiServer.memoryLimitPercent }}
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
         certSANs:
         - localhost
         - 127.0.0.1


### PR DESCRIPTION
As outlined in a recent Kubernetes 1.33 change [0], the `--cloud-provider` flag has been removed from `kube-apiserver`.

[0] https://github.com/kubernetes/kubernetes/pull/130162