### PR TITLE
Fix release numbering for clarity's sake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Update this for every tagged release.
-CHART_VERSION = 0.2.7
+CHART_VERSION = 0.3.0
 
 # Defines the versions to use for cluster API components.
 CAPI_VERSION = v1.11.7

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ There is a top level chart-of-charts that will just install everything as a big 
 ```shell
 helm repo add unikorn-cloud-capi https://unikorn-cloud.github.io/helm-cluster-api
 helm repo update
-helm upgrade --install cluster-api unikorn-cloud-capi/cluster-api -n cluster-api --create-namespace --version 0.2.7
+helm upgrade --install cluster-api unikorn-cloud-capi/cluster-api -n cluster-api --create-namespace --version 0.3.0
 ```
 </details>
 
@@ -47,7 +47,7 @@ spec:
   source:
     repoURL: https://unikorn-cloud.github.io/helm-cluster-api
     chart: cluster-api
-    targetRevision: 0.2.7
+    targetRevision: 0.3.0
   destination:
     server: https://kubernetes.default.svc
     namespace: cluster-api
@@ -89,7 +89,7 @@ You may want to be a little less gung-ho and deploy the pieces as separate appli
 ```shell
 helm repo add unikorn-cloud-capi https://unikorn-cloud.github.io/helm-cluster-api
 helm repo update
-helm upgrade --install cluster-api-core unikorn-cloud-capi/cluster-api-core -n cluster-api --create-namespace --version 0.2.7
+helm upgrade --install cluster-api-core unikorn-cloud-capi/cluster-api-core -n cluster-api --create-namespace --version 0.3.0
 ```
 </details>
 
@@ -108,7 +108,7 @@ spec:
   source:
     repoURL: https://unikorn-cloud.github.io/helm-cluster-api
     chart: cluster-api-core
-    targetRevision: 0.2.7
+    targetRevision: 0.3.0
   destination:
     server: https://kubernetes.default.svc
     namespace: cluster-api
@@ -141,7 +141,7 @@ spec:
 ```shell
 helm repo add unikorn-cloud-capi https://unikorn-cloud.github.io/helm-cluster-api
 helm repo update
-helm upgrade --install cluster-api-bootstrap-kubeadm unikorn-cloud-capi/cluster-api-bootstrap-kubeadm -n cluster-api --create-namespace --version 0.2.7
+helm upgrade --install cluster-api-bootstrap-kubeadm unikorn-cloud-capi/cluster-api-bootstrap-kubeadm -n cluster-api --create-namespace --version 0.3.0
 ```
 </details>
 
@@ -160,7 +160,7 @@ spec:
   source:
     repoURL: https://unikorn-cloud.github.io/helm-cluster-api
     chart: cluster-api-bootstrap-kubeadm
-    targetRevision: 0.2.7
+    targetRevision: 0.3.0
   destination:
     server: https://kubernetes.default.svc
     namespace: cluster-api
@@ -186,7 +186,7 @@ spec:
 ```shell
 helm repo add unikorn-cloud-capi https://unikorn-cloud.github.io/helm-cluster-api
 helm repo update
-helm upgrade --install cluster-api-control-plane-kubeadm unikorn-cloud-capi/cluster-api-control-plane-kubeadm -n cluster-api --create-namespace --version 0.2.7
+helm upgrade --install cluster-api-control-plane-kubeadm unikorn-cloud-capi/cluster-api-control-plane-kubeadm -n cluster-api --create-namespace --version 0.3.0
 ```
 </details>
 
@@ -205,7 +205,7 @@ spec:
   source:
     repoURL: https://unikorn-cloud.github.io/helm-cluster-api
     chart: cluster-api-control-plane-kubeadm
-    targetRevision: 0.2.7
+    targetRevision: 0.3.0
   destination:
     server: https://kubernetes.default.svc
     namespace: cluster-api

--- a/README.provider-openstack.md
+++ b/README.provider-openstack.md
@@ -8,7 +8,7 @@
 ```shell
 helm repo add unikorn-cloud-capi https://unikorn-cloud.github.io/helm-cluster-api
 helm repo update
-helm upgrade --install cluster-api-provider-openstack unikorn-cloud-capi/cluster-api-provider-openstack -n cluster-api --create-namespace --version 0.2.7
+helm upgrade --install cluster-api-provider-openstack unikorn-cloud-capi/cluster-api-provider-openstack -n cluster-api --create-namespace --version 0.3.0
 ```
 </details>
 
@@ -28,7 +28,7 @@ spec:
   source:
     repoURL: https://unikorn-cloud.github.io/helm-cluster-api
     chart: cluster-api-provider-openstack
-    targetRevision: 0.2.7
+    targetRevision: 0.3.0
   destination:
     server: https://kubernetes.default.svc
     namespace: cluster-api

--- a/charts/cluster-api-bootstrap-kubeadm/Chart.yaml
+++ b/charts/cluster-api-bootstrap-kubeadm/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for deploying cluster API.
 icon: https://assets.unikorn-cloud.org/assets/images/logos/dark-on-light/icon.png
 name: cluster-api-bootstrap-kubeadm
 type: application
-version: 0.2.7
+version: 0.3.0

--- a/charts/cluster-api-cluster-openstack/Chart.yaml
+++ b/charts/cluster-api-cluster-openstack/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-api-cluster-openstack
 description: A Helm chart to deploy a Kubernetes Cluster
 type: application
-version: 0.6.1
+version: 0.7.0
 icon: https://raw.githubusercontent.com/unikorn-cloud/helm-cluster-api/main/icons/default.png

--- a/charts/cluster-api-cluster-openstack/README.md
+++ b/charts/cluster-api-cluster-openstack/README.md
@@ -36,7 +36,7 @@ spec:
   source:
     repoURL: https://unikorn-cloud.github.io/helm-cluster-api
     chart: cluster-api-cluster-openstack
-    targetRevision: 0.6.1
+    targetRevision: 0.7.0
     helm:
       releaseName: foo
       # Remove the default work queue.

--- a/charts/cluster-api-control-plane-kubeadm/Chart.yaml
+++ b/charts/cluster-api-control-plane-kubeadm/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for deploying cluster API.
 icon: https://assets.unikorn-cloud.org/assets/images/logos/dark-on-light/icon.png
 name: cluster-api-control-plane-kubeadm
 type: application
-version: 0.2.7
+version: 0.3.0

--- a/charts/cluster-api-core/Chart.yaml
+++ b/charts/cluster-api-core/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for deploying cluster API.
 icon: https://assets.unikorn-cloud.org/assets/images/logos/dark-on-light/icon.png
 name: cluster-api-core
 type: application
-version: 0.2.7
+version: 0.3.0

--- a/charts/cluster-api-provider-openstack/Chart.yaml
+++ b/charts/cluster-api-provider-openstack/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for deploying cluster API.
 icon: https://assets.unikorn-cloud.org/assets/images/logos/dark-on-light/icon.png
 name: cluster-api-provider-openstack
 type: application
-version: 0.2.7
+version: 0.3.0

--- a/charts/cluster-api/Chart.yaml
+++ b/charts/cluster-api/Chart.yaml
@@ -3,25 +3,25 @@ appVersion: v1.11.7
 name: cluster-api
 description: A Helm chart to deploy Cluster API
 type: application
-version: 0.2.7
+version: 0.3.0
 icon: https://assets.unikorn-cloud.org/assets/images/logos/dark-on-light/icon.png
 
 dependencies:
 - name: cluster-api-core
-  version: 0.2.7
+  version: 0.3.0
   repository: file://../cluster-api-core
 - name: cluster-api-bootstrap-kubeadm
-  version: 0.2.7
+  version: 0.3.0
   repository: file://../cluster-api-bootstrap-kubeadm
   condition: kubeadm.enabled
 - name: cluster-api-control-plane-kubeadm
-  version: 0.2.7
+  version: 0.3.0
   repository: file://../cluster-api-control-plane-kubeadm
   condition: kubeadm.enabled
 - name: cluster-api-provider-openstack
-  version: 0.2.7
+  version: 0.3.0
   repository: file://../cluster-api-provider-openstack
   condition: openstack.enabled
 - name: openstack-resource-controller
-  version: 0.2.7
+  version: 0.3.0
   repository: file://../openstack-resource-controller

--- a/charts/openstack-resource-controller/Chart.yaml
+++ b/charts/openstack-resource-controller/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for deploying cluster API.
 icon: https://assets.unikorn-cloud.org/assets/images/logos/dark-on-light/icon.png
 name: openstack-resource-controller
 type: application
-version: 0.2.7
+version: 0.3.0


### PR DESCRIPTION
The previous release of the Helm charts in this repo do not align with semver, and while this isn't necessary a hard rule for this repo it does make it clearer to administrators that they're performing a significant upgrade versus a patch release.

This is especially pertinent for the cluster-api-cluster-openstack chart which accidentally retained the same version number (0.6.1), and only had the preceeding 'v' dropped due to the Helm v3 to v4 upgrade, making this extra confusing.