### PR TITLE
fix: adding wrapper around the file field as later verions of CAPI will validate this is not null

### DIFF
--- a/charts/cluster-api-cluster-openstack/templates/workload.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/workload.yaml
@@ -99,6 +99,7 @@ metadata:
 spec:
   template:
     spec:
+      {{- if or $pool.files $pool.kubelet $.Values.registryMirrors }}
       files:
       {{- range $file := $pool.files }}
       - content: {{ $file.content }}
@@ -123,6 +124,7 @@ spec:
         permissions: "0644"
         content: |
           {{- include "containerd.registry.content" (list $registry $mirrors) | nindent 10 }}
+      {{- end }}
       {{- end }}
       {{- end }}
       joinConfiguration:


### PR DESCRIPTION
I'm using the latest CAPI from upstream on the new uni dev and this bit me. We need to be able to ignore the files field if it's not supplied as it will cause a failure if it's null.

By wrapping it like this, we can ignore it.