### PR TITLE
fix: invalid type for rootVolume.availabilityZone, it should be an object (same as workload template).

### DIFF
--- a/charts/cluster-api-cluster-openstack/templates/control-plane.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/control-plane.yaml
@@ -127,7 +127,8 @@ spec:
         cloudName: {{ .Values.openstack.cloud }}
       {{- if .Values.controlPlane.machine.disk }}
       rootVolume:
-        availabilityZone: {{ .Values.openstack.volumeFailureDomain }}
+        availabilityZone:
+          name: {{ .Values.openstack.volumeFailureDomain }}
         sizeGiB: {{ .Values.controlPlane.machine.disk.size }}
       {{- end }}
       {{- with $cluster := .Values.cluster -}}


### PR DESCRIPTION
Not sure how this was working previously, I swear I didn't have this problem on a previous build using volume-based VMs. 

Changes availabilityZone argument in OpenstackMachineTemplate to be the correct type (an object) in the control plane machine template. 