### PR TITLE
chore: set openstack.volumeFailureDomain value as a default.

### DIFF
--- a/charts/cluster-api-cluster-openstack/Chart.yaml
+++ b/charts/cluster-api-cluster-openstack/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-api-cluster-openstack
 description: A Helm chart to deploy a Kubernetes Cluster
 type: application
-version: 0.8.0
+version: 0.8.1
 icon: https://raw.githubusercontent.com/unikorn-cloud/helm-cluster-api/main/icons/default.png

--- a/charts/cluster-api-cluster-openstack/README.md
+++ b/charts/cluster-api-cluster-openstack/README.md
@@ -36,7 +36,7 @@ spec:
   source:
     repoURL: https://unikorn-cloud.github.io/helm-cluster-api
     chart: cluster-api-cluster-openstack
-    targetRevision: 0.8.0
+    targetRevision: 0.8.1
     helm:
       releaseName: foo
       # Remove the default work queue.

--- a/charts/cluster-api-cluster-openstack/values.yaml
+++ b/charts/cluster-api-cluster-openstack/values.yaml
@@ -45,7 +45,7 @@ openstack:
 
   # If volumes are defined for machine sets, this is the global default.
   # It can be overidden on a per-workload pool/control plane basis.
-  # volumeFailureDomain: nova
+  volumeFailureDomain: nova
 
 # Cluster wide configuration.
 #


### PR DESCRIPTION
…so that if .disks is specified for control-plane machinetemplate, the volume's availabilityZone.name is set.

Minor fix to an issue that occurs if you set rootVolume but don't set volumeFailureDomain. 